### PR TITLE
Pass errors from createReadStream() into response

### DIFF
--- a/lib/drives/index.js
+++ b/lib/drives/index.js
@@ -479,7 +479,10 @@ class DriveManager extends EventEmitter {
         })
 
         pump(stream, rspMapper, call, err => {
-          if (err) log.error({ id, err }, 'createReadStream error')
+          if (err) {
+            log.error({ id, err }, 'createReadStream error')
+            call.destroy(err)
+          }
         })
       },
 


### PR DESCRIPTION
Currently `createReadStream()` will not propagate an error when it should, eg if you call it on a file that does not exist. This PR causes the error to be correctly passed into the responding stream. (I would've expected `pump()` to do that but for some reason it doesn't).