### PR TITLE
always set PATH in env

### DIFF
--- a/manager.js
+++ b/manager.js
@@ -12,6 +12,10 @@ async function start (opts = {}) {
   opts = { ...constants, ...opts }
   opts.endpoint = `localhost:${opts.port}`
 
+  if (opts.env && !opts.env.PATH) {
+    opts.env = { ...opts.env, PATH: process.env.PATH }
+  }
+
   const client = new HyperdriveClient(opts.endpoint, { storage: initialOpts.storage || opts.root })
   const running = await new Promise((resolve, reject) => {
     client.ready(err => {


### PR DESCRIPTION
Fixes unmount on mac.

The process env is currently empty as the env from hyperdrive-daemon-client/lib/constants overwrites it.

This PR always sets the PATH as that's needed for OSX to find diskutil