### PR TITLE
Fix: use default logLevel

### DIFF
--- a/manager.js
+++ b/manager.js
@@ -38,7 +38,7 @@ async function start (opts = {}) {
   opts.memoryOnly = opts['memory-only']
   opts.noAnnounce = opts['no-announce']
   opts.noTelemetry = opts['no-telemetry']
-  opts.logLevel = opts['log-level']
+  opts.logLevel = opts['log-level'] ? opts['log-level'] : opts.logLevel
 
   /**
    * HACK


### PR DESCRIPTION
Hello 👋 This is a small fix for the `manager.js` `start` method. I found that if you call `start` programatically it ends up with a silent error that prevents the client to connect to the daemon (because the daemon doesn't start).

The error can be seen in the logs: `default level:true must be included in custom levels`.