### PR TITLE
fix: grammar on mountpoint message

### DIFF
--- a/lib/fuse/index.js
+++ b/lib/fuse/index.js
@@ -430,7 +430,7 @@ class FuseManager extends EventEmitter {
 
   async _infoForPath (path) {
     if (!this._rootDrive) throw new Error('Cannot get mountpoint info when a root drive is not mounted.')
-    if (!path.startsWith(this._rootMnt)) throw new Error(`The mountpoint must be a beneath ${constants.mountpoint}.`)
+    if (!path.startsWith(this._rootMnt)) throw new Error(`The mountpoint must be beneath ${constants.mountpoint}.`)
     const self = this
 
     if (path !== this._rootMnt) {


### PR DESCRIPTION
Before:
```js
Error(`The mountpoint must be a beneath ${constants.mountpoint}.`)
```

After:
```js
Error(`The mountpoint must be beneath ${constants.mountpoint}.`)
```