### PR TITLE
WIP Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,3 +8,4 @@ RUN npm install
 COPY . /usr/src/hyperdrive-daemon/
 
 ENTRYPOINT [ "./bin/run/run" ]
+CMD [ "start", "--foreground" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:lts
+
+WORKDIR /usr/src/hyperdrive-daemon/
+
+COPY ./package.json /usr/src/hyperdrive-daemon/
+RUN npm install
+
+COPY . /usr/src/hyperdrive-daemon/
+
+ENTRYPOINT [ "./bin/run/run" ]


### PR DESCRIPTION
Setting the ball rolling, since community feedback is desired.
As of now, just download deps and add code. Entrypoint calls main `run` command and, if no further command line args are provided, defaults to starting a daemon (in foreground as per Docker requirement). I'm not a NodeJS developer, so feedback is much appreciated.
Add Dockerfile to enable image building.
Using the official NodeJS image, latest LTS tag. More info at https://hub.docker.com/_/node/
Note: Readme states that there is an issue preventing NodeJS 14 from working, but the issue is closed. I went for latest LTS (~~14~~12 as per NodeJS Docker Hub page). Maybe the readme notice is no longer valid?

Build:

```
$ docker build -t hyperdrive-daemon .
```

Run:

```
$ docker run --rm -it -p 3101:3101 hyperdrive-daemon [options...]
```

FYI, there's a still quicker to test, already built image on my Docker Hub. Test it by running:

```
$ docker run --rm -it -p 3101:3101 pataquets/hyperdrive-daemon-src [options...]
```

Using `--rm` instead of `-d` makes the container not go background and it to be deleted after stop. Should stop by `CTRL+C`'ing it.

FUSE packages and OS support is still not present, but it is feasible under Docker. I guess it's the next thing to add, but merging can provide a base image (with hopefully an [Automated Build](https://docs.docker.com/docker-hub/builds/)) in the meantime for others to base on and contribute and improve further. But that can be dealt with in different issues later.